### PR TITLE
 Introduce ChainIt setting - auto_exception_handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # ChainIt
-[![CircleCI](https://circleci.com/gh/spark-solutions/chain_it/tree/master.svg?style=svg&circle-token=3bb16aef0dbcbe7fd18500376a110bd6cedf668a)](https://circleci.com/gh/spark-solutions/ChainIt/tree/master)
+### Gain full control over what is going in your code!
+[![CircleCI](https://circleci.com/gh/tier-tools/chainit/tree/master.svg?style=svg)](https://circleci.com/gh/tier-tools/chainit/tree/master)
 
-## Description
-This provides the tool which is implementation of railway-oriented programming concept itself
-(Read more on this <a href="https://fsharpforfunandprofit.com/rop">here</a>).
+## What exactly is `ChainIt`?
+It's the  Ruby implementation of a railway-oriented programming concept. <a href="https://fsharpforfunandprofit.com/rop">read more</a> 
 
-Ideally suited for executing task sequences that should be immediately interrupted when any subsequen task fails.
+The gem makes it super easy to control complex operations flow - the next step will happen only if the previous one was successful.
 
-## Usage
-Everything comes down to chaining subsequent `#chain` method calls to a `ChainIt` object instance.
+Ideally suited for handling task sequences that should be  interrupted as soon as any subsequent task fails.
 
-The gem supports design-by-contract programming concept - assuming every block related to `#chain` have to return both `#value` and `#failure?` aware object.We reccomend using Struct for that purpouse.
+## How should I use `ChainIt`?
+As not hard to guess, alll is about chaining subsequent `#chain` method calls to a `ChainIt` instance.
+
+### Prerequisites
+The gem supports design-by-contract programming concept assuming `ChainIt` will be used together with both `#value` and `#failure?` aware object that have to be returned by every `#chain`related block. It is used to consider the operation successful or failed.
+
+We reccomend using `Struct`:
 
 ```ruby
 Result = Struct.new(:success, :value) do
@@ -20,42 +25,68 @@ Result = Struct.new(:success, :value) do
 end
 
 ```
-### Examples
+### Interface explanation
+`#initialize` - Initiates the operation. Auto exception handling mode is configurable here. (see examples section)</br>
+`#chain` - Performs the code in its related block and memorizes the internal result value. This is done only when the state of the operation allows it.</br>
+`#skip_next` - Skips the next `#chain` call when it's block evaluates to `true`.</br>
+`#result` - The result of the operation representing succes of failure. </br>
 
+### `ChainIt` modes
+`auto_exception_handling` - default `false` - Decide if any `StandardError` exception should be rescued from any `#chain` call. If so the rescued exception will be memorized as operation result object.
+
+### Examples </br>
+#### Success path
 ```ruby
-# Basic flow explanation
 success = ->(value) { Result.new(true, value) }
 
 ChainIt.new.
-        chain { success.call 2 }.               #=> The subsequent chain will be triggered
-        chain { |num| success.call(num * 2) }.  #=> We can pass the previous block evaluation as the block argument
-        chain { |num| success.call(num * 2) }.
-        result.
-        value                                   #=> 8
-
-# Working with #skip_next
-ChainIt.new.
         chain { success.call 2 }.               
-        skip_next { |num| num == 2 }.           #=> The next chain will be skipped conditionally since block returns true
-        chain { success.call 8 }.              
-        chain { |num| success.call(num * 2) }.  #=> The block argument is the last executed #chain value
-        result.
+        chain { |num| success.call(num * 2) }.  # The operation result is passed as block argument if used.
+        result.                                 #=> <struct Result success=true, value=4>
         value                                   #=> 4
 
-# Dealing with a failure
+```
+
+#### Failure path
+```ruby
 failure = ->(value) { Result.new(false, value) }
 
 ChainIt.new.
         chain { success.call 2 }.
-        chain { failure.call 0 }.               #=> All later #chain calls will be skipped
+        chain { failure.call 0 }.               # All later steps calls will be skipped. 
         chain { success.call 4 }.
-        result.
+        result.                                 #=> <struct Result success=false, value=0>
         value                                   #=> 0
 ```
-## Contributing
+#### Working with `#skip_next`
+```ruby
+ChainIt.new.
+        chain { success.call 2 }.               
+        skip_next { |num| num == 2 }.           # The next chain will be skipped as the block evaluates to true.
+        chain { success.call 8 }.              
+        result.                                 #=> <struct Result success=true, value=2>
+        value                                   #=> 2
+```
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/spark-solutions/chain_it.
+#### With `auto_exception_handling` mode disabled
+```ruby
+ChainIt.new.
+        chain { raise StandardError.new }.      #=> StandardError: StandardError                             
+        result.                                 
+        value
+```
 
-## License
+#### With `auto_exception_handling` mode enabled
+```ruby
+ChainIt.new(auto_exception_handling: true).
+        chain { raise StandardError.new }.
+        result.                                  #=> <StandardError: StandardError>
+        value                                    #=> <StandardError: StandardError>
+```
+
+## Develop `ChainIt`
+All the contributions are really welcome on GitHub at https://github.com/tier-tools/chainit according to the open-source spirit.
+
+## `ChainIt` License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/lib/chain_it.rb
+++ b/lib/chain_it.rb
@@ -1,5 +1,10 @@
 class ChainIt
+  DEFAULT_SETTINGS = { auto_exception_handling: false }.freeze
   INVALID_RESULT_MSG = "ChainIt#chain block must return both #value and #failure? aware object.\n Check documentation: https://github.com/spark-solutions/chain_it#usage"
+
+  def initialize(settings = {})
+    @settings = DEFAULT_SETTINGS.merge(settings)
+  end
 
   def chain
     if @skip_next
@@ -12,6 +17,14 @@ class ChainIt
 
     @result = yield result_value
     @skip = true if result_failure?
+    self
+  rescue StandardError => e
+    raise e unless @settings[:auto_exception_handling]
+
+    e.define_singleton_method(:value) { e }
+    @result = e
+
+    @skip = true
     self
   end
 

--- a/lib/chain_it/version.rb
+++ b/lib/chain_it/version.rb
@@ -1,3 +1,3 @@
 class ChainIt
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/chain_it_spec.rb
+++ b/spec/chain_it_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe ChainIt do
@@ -13,8 +15,32 @@ RSpec.describe ChainIt do
       let(:result_object) { Struct.new('Result') }
 
       it 'responds with self explanatory error' do
-        expect { subject.chain { service_object.call } }.
-          to raise_error(StandardError, ChainIt::INVALID_RESULT_MSG)
+        expect { subject.chain { service_object.call } }
+          .to raise_error(StandardError, ChainIt::INVALID_RESULT_MSG)
+      end
+    end
+
+    context 'when the code within the block raises error' do
+      subject { described_class.new(opts) }
+
+      before { allow(subject).to receive(:result_value).and_raise }
+
+      context 'with :auto_exception_handling mode' do
+        context 'enabled' do
+          let(:opts) { { auto_exception_handling: true } }
+
+          it 'rescues the error' do
+            expect { subject.chain { service_object.call } }.not_to raise_error
+          end
+        end
+
+        context 'disabled' do
+          let(:opts) { { auto_exception_handling: false } }
+
+          it 're-raises the error' do
+            expect { subject.chain { service_object.call } }.to raise_error
+          end
+        end
       end
     end
   end
@@ -22,19 +48,19 @@ RSpec.describe ChainIt do
   describe '#skip_next' do
     context 'when passed block evaluates to true' do
       it 'skips the next #chain execution' do
-	expect(service_object).not_to receive(:call)
+        expect(service_object).not_to receive(:call)
 
-	subject.skip_next { true }.
-	        chain { service_object.call }
+        subject.skip_next { true }
+               .chain { service_object.call }
       end
     end
 
     context 'when passed block evaluates to false' do
       it 'does not skip the next #chain execution' do
-       	expect(service_object).to receive(:call)
+        expect(service_object).to receive(:call)
 
-        subject.skip_next { false }.
-                chain { service_object.call }
+        subject.skip_next { false }
+               .chain { service_object.call }
       end
     end
   end
@@ -47,19 +73,34 @@ RSpec.describe ChainIt do
 
     context 'when all the chanis are successful' do
       it 'returns the last chain\'s response' do
-        expect(subject.chain { service_object.call }.
-                       chain { service_object2.call }.
-                       result).to eq result_object2
+        expect(subject.chain { service_object.call }
+                       .chain { service_object2.call }
+                       .result).to eq result_object2
       end
     end
 
     context 'when some chain is failed' do
       let(:result_object) { double('result object', failure?: true, value: false) }
 
+      context 'by raising the exception' do
+        subject { described_class.new(opts) }
+
+        before { allow(subject).to receive(:result_value).and_raise }
+
+        context 'with auto_exception_handling mode enabled' do
+          let(:opts) { { auto_exception_handling: true } }
+
+          it 'returns the error object' do
+            expect(subject.chain { service_object.call }
+                           .result).to be_a StandardError
+          end
+        end
+      end
+
       it 'returns the last successful chain\'s response' do
-        expect(subject.chain { service_object.call }.
-                       chain { service_object2.call }.
-                       result).to eq result_object
+        expect(subject.chain { service_object.call }
+                       .chain { service_object2.call }
+                       .result).to eq result_object
       end
     end
   end

--- a/spec/chain_it_spec.rb
+++ b/spec/chain_it_spec.rb
@@ -142,6 +142,6 @@ RSpec.describe ChainIt do
   end
 
   it 'has a version number' do
-    expect(ChainIt::VERSION).to eq '1.1.0'
+    expect(ChainIt::VERSION).to eq '1.2.0'
   end
 end


### PR DESCRIPTION
It enables options for out `ChainIt`. Now we choose if any raised error within the `#chain` block should be rescued and returned via `#result` or not handled at all.

<strike>Still have to make a PR with `README.md` file updated with the changes introduced by these commits</strike>